### PR TITLE
Minor update to Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ pod "SugarRecord/Realm+RAC"
 
 ### [Carthage](https://carthage)
 1. Install [Carthage](https://github.com/carthage/carthage) on your computer using `brew install carthage`
-3. Edit your `Cartfile` file adding the following line `github 'pepibumur/sugarrecord'`
+3. Edit your `Cartfile` file adding the following line `github "pepibumur/sugarrecord"`
 4. Update and build frameworks with `carthage update`
 5. Add generated frameworks to your app main target following the steps [here](https://github.com/carthage/carthage)
 6. Link your target with **CoreData** library *(from Build Phases)*


### PR DESCRIPTION
Made correction to the instruction for Carthage setup, under step 2. Target repository URL has to be surrounded by double quotation marks instead of single.