### PR TITLE
Migrate Tailor rule config from run script to .tailor.yml

### DIFF
--- a/.tailor.yml
+++ b/.tailor.yml
@@ -1,2 +1,7 @@
 include:
   - SugarRecord
+except:
+  - leading-whitespace  
+  - trailing-whitespace 
+  - comment-whitespace
+  - lower-camel-case

--- a/SugarRecord.xcodeproj/project.pbxproj
+++ b/SugarRecord.xcodeproj/project.pbxproj
@@ -1258,7 +1258,7 @@
 				3DB2B82A1BDEE187005B7EF2 /* Headers */,
 				3DB2B82B1BDEE187005B7EF2 /* Resources */,
 				3D7586481C1615E500F64E22 /* Bump version */,
-				73E87420F3EF20AA2076D3DE /* Tailor */,
+				B162B35A3F40765F8F9F6A7F /* Tailor */,
 			);
 			buildRules = (
 			);
@@ -1480,7 +1480,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if hash tailor 2>/dev/null; then\ntailor --except=leading-whitespace,trailing-whitespace,comment-whitespace,lower-camel-case\nelse\necho \"warning: Please install Tailor from https://tailor.sh\"\nfi";
+			shellScript = "if hash tailor 2>/dev/null; then\n  tailor\nelse\n  echo \"warning: Please install Tailor from https://tailor.sh\"\nfi";
 		};
 		2318A6781C3AE420003ACD13 /* Tailor */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1494,7 +1494,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if hash tailor 2>/dev/null; then\ntailor --except=leading-whitespace,trailing-whitespace,comment-whitespace,lower-camel-case\nelse\necho \"warning: Please install Tailor from https://tailor.sh\"\nfi";
+			shellScript = "if hash tailor 2>/dev/null; then\n  tailor\nelse\n  echo \"warning: Please install Tailor from https://tailor.sh\"\nfi";
 		};
 		2318A6791C3AE428003ACD13 /* Tailor */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1508,7 +1508,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if hash tailor 2>/dev/null; then\ntailor --except=leading-whitespace,trailing-whitespace,comment-whitespace,lower-camel-case\nelse\necho \"warning: Please install Tailor from https://tailor.sh\"\nfi";
+			shellScript = "if hash tailor 2>/dev/null; then\n  tailor --except=leading-whitespace,trailing-whitespace,comment-whitespace,lower-camel-case\nelse\n  echo \"warning: Please install Tailor from https://tailor.sh\"\nfi";
 		};
 		2318A67A1C3AE430003ACD13 /* Tailor */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1522,7 +1522,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if hash tailor 2>/dev/null; then\ntailor --except=leading-whitespace,trailing-whitespace,comment-whitespace,lower-camel-case\nelse\necho \"warning: Please install Tailor from https://tailor.sh\"\nfi";
+			shellScript = "if hash tailor 2>/dev/null; then\n  tailor\nelse\n  echo \"warning: Please install Tailor from https://tailor.sh\"\nfi";
 		};
 		2318A67B1C3AE439003ACD13 /* Tailor */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1536,7 +1536,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if hash tailor 2>/dev/null; then\ntailor --except=leading-whitespace,trailing-whitespace,comment-whitespace,lower-camel-case\nelse\necho \"warning: Please install Tailor from https://tailor.sh\"\nfi";
+			shellScript = "if hash tailor 2>/dev/null; then\n  tailor\nelse\n  echo \"warning: Please install Tailor from https://tailor.sh\"\nfi";
 		};
 		2318A67C1C3AE441003ACD13 /* Tailor */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1550,7 +1550,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if hash tailor 2>/dev/null; then\ntailor --except=leading-whitespace,trailing-whitespace,comment-whitespace,lower-camel-case\nelse\necho \"warning: Please install Tailor from https://tailor.sh\"\nfi";
+			shellScript = "if hash tailor 2>/dev/null; then\n  tailor\nelse\n  echo \"warning: Please install Tailor from https://tailor.sh\"\nfi";
 		};
 		2318A67D1C3AE449003ACD13 /* Tailor */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1564,7 +1564,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if hash tailor 2>/dev/null; then\ntailor --except=leading-whitespace,trailing-whitespace,comment-whitespace,lower-camel-case\nelse\necho \"warning: Please install Tailor from https://tailor.sh\"\nfi";
+			shellScript = "if hash tailor 2>/dev/null; then\n  tailor\nelse\n  echo \"warning: Please install Tailor from https://tailor.sh\"\nfi";
 		};
 		2319B7F61C23FF8F0050ABE8 /* Bump version */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1678,7 +1678,7 @@
 			shellPath = "/usr/bin/env ruby";
 			shellScript = "git = `sh /etc/profile; which git`.chomp\napp_build = `#{git} rev-list --all | wc -l`.chomp.to_i\n`/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion #{app_build}\" \"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"`\nputs \"Updated #{ENV['TARGET_BUILD_DIR']}/#{ENV['INFOPLIST_PATH']}\"";
 		};
-		73E87420F3EF20AA2076D3DE /* Tailor */ = {
+		B162B35A3F40765F8F9F6A7F /* Tailor */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1690,7 +1690,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if hash tailor 2>/dev/null; then\n  tailor --except=leading-whitespace,trailing-whitespace,comment-whitespace,lower-camel-case\nelse\n  echo \"warning: Please install Tailor from https://tailor.sh\"\nfi";
+			shellScript = "if hash tailor 2>/dev/null; then\n  tailor\nelse\n  echo \"warning: Please install Tailor from https://tailor.sh\"\nfi";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
The functionality for filtering rules via `.tailor.yml` is availble in [Tailor v0.6.0](https://github.com/sleekbyte/tailor/releases)