### PR TITLE
added update flag to Realm insert

### DIFF
--- a/SugarRecord/Source/Realm/Extensions/Realm.swift
+++ b/SugarRecord/Source/Realm/Extensions/Realm.swift
@@ -33,7 +33,7 @@ extension Realm: Context {
      */
     public func insert<T: Entity>(entity: T) throws {
         guard let _ = T.self as? Object.Type else { throw Error.InvalidType }
-        self.add(entity as! Object)
+        self.add(entity as! Object, update: true)
     }
     
     /**


### PR DESCRIPTION
With the update flag set to true on an `Realm.add` call, if an object exists in the realm with the same primary key as the object being inserted, the object is simply updated. If no key exists, then a new object is created.